### PR TITLE
Add/fix missing keyboard shortcuts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-session (2.0.5) bionic; urgency=medium
+
+  * Add missing keyboard shortcuts
+
+ -- Benjamin Shpurker <benjamin@system76.com>  Wed, 23 May 2018 08:12:49 -0600
+
 pop-session (2.0.4) bionic; urgency=medium
 
   * Add more extensions

--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -7,6 +7,10 @@ always-show-log-out = true
 app-picker-view = 1
 enable-hot-corners = false
 
+[org.gnome.shell.keybindings:pop]
+open-application-menu = ['<Super>m']
+toggle-message-tray = ['<Super>v']
+
 [org.gnome.desktop.app-folders:pop]
 folder-children = ['Pop-Office', 'Pop-System', 'Pop-Utility']
 

--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -51,6 +51,7 @@ switch-to-workspace-right = ['<Super>Right']
 switch-to-workspace-up = ['<Super>Up']
 toggle-maximized = ['<Primary><Super>Up']
 unmaximize = ['<Primary><Super>Down']
+show-desktop = ['<Super>d']
 
 [org.gnome.desktop.wm.preferences:pop]
 resize-with-right-button = true


### PR DESCRIPTION
Should fix https://github.com/pop-os/pop/issues/171
Fixed <kbd>Super</kbd>+<kbd>m</kbd> (Show application menu)
Note: Removed <kbd>Super</kbd>+<kbd>m</kbd> from toggling message tray (since <kbd>Super</kbd>+<kbd>v</kbd> already does that)
Fixed <kbd>Super</kbd>+<kbd>d</kbd> (Show desktop)
Fixed <kbd>Super</kbd>+<kbd>f</kbd> (Open files)

All of these should work now: http://pop.system76.com/docs/keyboard-shortcuts/
