### PR TITLE
Remove the "Always Show Workspaces" extension in cosmic, as it is the default behavior in 18.10

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,6 @@ Architecture: any
 Depends: ${misc:Depends},
          gnome-shell,
          gnome-shell-extension-alt-tab-raise-first-window,
-         gnome-shell-extension-always-show-workspaces,
          gnome-shell-extension-do-not-disturb,
          gnome-shell-extension-pop-battery-icon-fix,
          gnome-shell-extension-pop-shop-details,

--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -94,7 +94,7 @@ power-button-action = 'interactive'
 antialiasing = 'grayscale'
 
 [org.gnome.shell:pop]
-enabled-extensions = ['alt-tab-raise-first-window@system76.com', 'always-show-workspaces@system76.com', 'batteryiconfix@kylecorry31.github.io', 'donotdisturb@kylecorry31.github.io', 'pop-shop-details@system76.com', 'pop-suspend-button@system76.com', 'system76-power@system76.com']
+enabled-extensions = ['alt-tab-raise-first-window@system76.com', 'batteryiconfix@kylecorry31.github.io', 'donotdisturb@kylecorry31.github.io', 'pop-shop-details@system76.com', 'pop-suspend-button@system76.com', 'system76-power@system76.com']
 
 #####################
 # Touchpad settings #


### PR DESCRIPTION
@brs17 One less extension required.