### PR TITLE
4.0.6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+pop-session (4.0.6) focal; urgency=medium
+
+  * Set split left/right to super+ctrl+left/right
+  * Set enabled extensions in gsettings
+
+ -- Jeremy Soller <jeremy@system76.com>  Wed, 22 Apr 2020 09:46:57 -0600
+
 pop-session (4.0.5) focal; urgency=medium
 
   * Re-add always-show-workspaces extension

--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -82,8 +82,8 @@ dynamic-workspaces = true
 workspaces-only-on-primary = false
 
 [org.gnome.mutter.keybindings]
-toggle-tiled-left = []
-toggle-tiled-right = []
+toggle-tiled-left = ['<Primary><Super>Left']
+toggle-tiled-right = ['<Primary><Super>Right']
 
 [org.gnome.mutter.wayland.keybindings]
 restore-shortcuts = []
@@ -105,7 +105,7 @@ power-button-action = 'interactive'
 antialiasing = 'grayscale'
 
 [org.gnome.shell:pop]
-enabled-extensions = []
+enabled-extensions = ['alt-tab-raise-first-window@system76.com', 'always-show-workspaces@system76.com', 'batteryiconfix@kylecorry31.github.io', 'desktop-icons@csoriano', 'pop-shell@system76.com', 'pop-shop-details@system76.com', 'system76-power@system76.com', 'ubuntu-appindicators@ubuntu.com']
 
 [org.gnome.shell.overrides:pop]
 attach-modal-dialogs = false


### PR DESCRIPTION
* Set split left/right to super+ctrl+left/right
* Set enabled extensions in gsettings

May fix #14 and system76-power disabled by default