### PR TITLE
remove always show workspaces extension as GNOME does this by default

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,6 @@ Architecture: all
 Depends: ${misc:Depends},
          gnome-shell,
          gnome-shell-extension-alt-tab-raise-first-window,
-         gnome-shell-extension-always-show-workspaces,
          gnome-shell-extension-appindicator,
          gnome-shell-extension-desktop-icons,
          gnome-shell-extension-pop-battery-icon-fix,


### PR DESCRIPTION
I believe this feature was added in GNOME 3.36 so we shouldn't need the extension any more for both 20.04 LTS or 20.10. 