### PR TITLE
Disable showing mounts on desktop by default

### DIFF
--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -126,6 +126,7 @@ workspaces-only-on-primary = false
 [org.gnome.shell.extensions.desktop-icons:pop]
 show-home = false
 show-trash = false
+show-mount = false
 
 #####################
 # Touchpad settings #


### PR DESCRIPTION
Pop 20.04 doesn't show any icons on the desktop by default. 20.10 currently shows mounted volumes on the desktop by default. This PR changes the default to not show any icons (other than files/folders in the Desktop folder.)

(Trying again, based on master_groovy.)