### PR TITLE
fix: Hide volumes on desktop by default (groovy)

### DIFF
--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -126,7 +126,7 @@ workspaces-only-on-primary = false
 [org.gnome.shell.extensions.ding:pop]
 show-home = false
 show-trash = false
-show-mount = false
+show-volumes = false
 
 #####################
 # Touchpad settings #


### PR DESCRIPTION
In https://github.com/pop-os/session/pull/26, `show-volumes` needed to be set, but instead we carried over the `show-mount` option from the extension we were replacing (which no longer exists in the new extension.) This PR switches to the correct `show-volumes` option so mounted volumes will be hidden by default.