### PR TITLE
fix: Hide volumes on desktop by default (focal)

### DIFF
--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -126,6 +126,7 @@ workspaces-only-on-primary = false
 [org.gnome.shell.extensions.ding:pop]
 show-home = false
 show-trash = false
+show-volumes = false
 
 #####################
 # Touchpad settings #


### PR DESCRIPTION
In https://github.com/pop-os/session/pull/27, we carried over the old extension's settings into the new extension, and the old extension did not have a `show-mount` setting; however, the new extension does have a `show-volumes` setting, which we want to set to false so mounted volumes are hidden by default.