### PR TITLE
This commit brings back the Min and Max buttons to Mutter 

### DIFF
--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -76,6 +76,7 @@ resize-with-right-button = true
 theme = "Pop"
 titlebar-font = 'Fira Sans Semi-Bold 10'
 titlebar-uses-system-font = false
+button-layout = 'menu:minimize,maximize,close'
 
 [org.gnome.nautilus.desktop:pop]
 home-icon-visible = false


### PR DESCRIPTION
This improves the user experience for our customers who expect the buttons when they moved from another OS that includes them by default.