### PR TITLE
focal: Support numpad in default keybindings (and missing h/l bindings)

### DIFF
--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -92,8 +92,8 @@ edge-tiling = true
 workspaces-only-on-primary = false
 
 [org.gnome.mutter.keybindings]
-toggle-tiled-left = ['<Primary><Super>Left', '<Primary><Super>KP_Left']
-toggle-tiled-right = ['<Primary><Super>Right', '<Primary><Super>KP_Right']
+toggle-tiled-left = ['<Primary><Super>Left', '<Primary><Super>KP_Left', '<Primary><Super>h']
+toggle-tiled-right = ['<Primary><Super>Right', '<Primary><Super>KP_Right', '<Primary><Super>l']
 
 [org.gnome.mutter.wayland.keybindings]
 restore-shortcuts = []

--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -63,10 +63,10 @@ move-to-workspace-down = []
 move-to-workspace-left = []
 move-to-workspace-right = []
 move-to-workspace-up = []
-switch-to-workspace-down = ['<Primary><Super>Down', '<Primary><Super>j']
+switch-to-workspace-down = ['<Primary><Super>Down', '<Primary><Super>KP_Down', '<Primary><Super>j']
 switch-to-workspace-left = []
 switch-to-workspace-right = []
-switch-to-workspace-up = ['<Primary><Super>Up', '<Primary><Super>k']
+switch-to-workspace-up = ['<Primary><Super>Up', '<Primary><Super>KP_Up', '<Primary><Super>k']
 toggle-maximized = ['<Super>m']
 unmaximize = []
 show-desktop = []
@@ -92,8 +92,8 @@ edge-tiling = true
 workspaces-only-on-primary = false
 
 [org.gnome.mutter.keybindings]
-toggle-tiled-left = ['<Primary><Super>Left']
-toggle-tiled-right = ['<Primary><Super>Right']
+toggle-tiled-left = ['<Primary><Super>Left', '<Primary><Super>KP_Left']
+toggle-tiled-right = ['<Primary><Super>Right', '<Primary><Super>KP_Right']
 
 [org.gnome.mutter.wayland.keybindings]
 restore-shortcuts = []


### PR DESCRIPTION
Focal version of https://github.com/pop-os/session/pull/36.