### PR TITLE
Unset default legacy `Show the activities overview` keyboard shortcut

### DIFF
--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -74,6 +74,7 @@ switch-to-workspace-up = ['<Primary><Super>Up', '<Primary><Super>KP_Up', '<Prima
 toggle-maximized = ['<Super>m']
 unmaximize = []
 show-desktop = []
+panel-main-menu = []
 
 [org.gnome.desktop.wm.preferences:pop]
 button-layout = 'appmenu:minimize,close'


### PR DESCRIPTION
Goes with https://github.com/pop-os/mutter/pull/22.

Since this legacy shortcut is not needed and being removed from the GUI, we should unset it so as not to have an immutable, unexpected keyboard shortcut present by default. If someone wants to use this shortcut, they can just set `Show workspaces` to Alt-F1 in Settings, since that's the new shortcut that does the same thing.