### PR TITLE
Add overrides for vertical-overview extension

### DIFF
--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -127,6 +127,13 @@ show-home = false
 show-trash = false
 show-volumes = false
 
+[org.gnome.shell.extensions.vertical-overview:pop]
+override-dash = false
+static-background = true
+scaling-workspace-background = true
+old-style = false
+default-old-style = false
+
 #####################
 # Touchpad settings #
 #####################


### PR DESCRIPTION
These changes are currently done directly in the XML schema of the gnome-shell-extension-vertical-overview pop package.  These changes make more sense as overrides in the pop session, similar to how it is handled for gnome-shell-extension-desktop-icons-ng.

This will also make packaging on Fedora easier, as we already ship gnome-shell-extension-vertical-overview with the default upstream settings.

https://github.com/pop-os/gnome-shell-extension-vertical-overview/commit/b91fb6459c41730b37821d01b7d9536ddc57654b
https://github.com/pop-os/gnome-shell-extension-vertical-overview/commit/6c7427692100c98abc574940443a2b94ffa72881