### PR TITLE
Preserve default alt-f4 close shortcut

### DIFF
--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -58,7 +58,7 @@ startup-mode = 'cwd'
 clock-format = '12h'
 
 [org.gnome.desktop.wm.keybindings:pop]
-close = ['<Super>q']
+close = ['<Alt>F4', '<Super>q']
 maximize = []
 minimize = []
 move-to-monitor-down = []


### PR DESCRIPTION
Alt-f4 is a common shortcut that many users expect to work.  It doesn't conflict with other Pop shortcuts, so it's worthwhile to preserve it.