### PR TITLE
Add WiFi Settings Key

### DIFF
--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -112,6 +112,7 @@ home = ['<Super>f']
 screensaver = ['<Super>Escape']
 terminal = ['<Super>t']
 www = ['<Super>b']
+custom-keybindings = ['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/PopLaunch1/']
 
 [org.gnome.settings-daemon.plugins.power:pop]
 power-button-action = 'interactive'


### PR DESCRIPTION
Set <FN\>f12 to open wifi settings on the HP DEV ONE

This is done by creating a custom keybinding that maps
`Launch1` to `gnome-control-center wifi`

Requires pop-os/default-settings#132