### PR TITLE
Set org.gnome.desktop.interface color-scheme to prefer-dark

### DIFF
--- a/debian/pop-session.gsettings-override
+++ b/debian/pop-session.gsettings-override
@@ -33,6 +33,7 @@ show-desktop-icons = true
 automatic-timezone=true
 
 [org.gnome.desktop.interface:pop]
+color-scheme = "prefer-dark"
 gtk-theme = "Pop-dark"
 icon-theme = "Pop"
 cursor-theme = "Pop"


### PR DESCRIPTION
Fixes #51