### PR TITLE
fix(shell-modes): add workspace gestures extension to enabled extensions

### DIFF
--- a/usr/share/gnome-shell/modes/pop.json
+++ b/usr/share/gnome-shell/modes/pop.json
@@ -9,6 +9,7 @@
         "system76-power@system76.com",
         "ubuntu-appindicators@ubuntu.com",
         "cosmic-dock@system76.com",
-        "cosmic-workspaces@system76.com"
+        "cosmic-workspaces@system76.com",
+        "popx11gestures@system76.com"
     ]
 }


### PR DESCRIPTION
Adds the extension to the default shell mode.